### PR TITLE
Disallow incrementing/decrementing by zero quantity and spaces after prefixes

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -34,7 +34,7 @@ This is a simplified class diagram of the Parser component, which provides a hig
 
 ![](diagrams/ParserClassDiagramSimplified.png)
 
-This is a more detailed class diagram of the `Parser`, `ArgsParser`, and `Prefix` classes. Note that `Parser` has 4 single arg prefixes, 3 multiple arg prefixes, and 3 optional arg prefixes. These prefixes correspond to the various arguments that are accepted by the various commands.
+This is a more detailed class diagram of the `Parser`, `ArgsParser`, and `Prefix` classes. Note that `Parser` has 4 single arg prefixes, 3 multiple arg prefixes, and 1 optional arg prefix. These prefixes correspond to the various arguments that are accepted by the various commands.
 
 ![](diagrams/ParserClassDiagram.png)
 

--- a/src/main/java/expiryeliminator/commands/AddRecipeCommand.java
+++ b/src/main/java/expiryeliminator/commands/AddRecipeCommand.java
@@ -59,7 +59,7 @@ public class AddRecipeCommand extends Command {
 
         for (int i = 0; i < ingredientNames.size(); i++) {
             try {
-                message += recipe.add(ingredientNames.get(i), quantities.get(i), ingredients);
+                message += recipe.addIngredient(ingredientNames.get(i), quantities.get(i), ingredients);
             } catch (DuplicateDataException e) {
                 return String.format(MESSAGE_DUPLICATE_INGREDIENT, name, ingredientNames.get(i));
             } catch (IllegalValueException e) {

--- a/src/main/java/expiryeliminator/commands/DecrementCommand.java
+++ b/src/main/java/expiryeliminator/commands/DecrementCommand.java
@@ -17,8 +17,9 @@ public class DecrementCommand extends Command {
                     + "Parameters: i/INGREDIENT q/QUANTITY e/EXPIRY_DATE\n"
                     + "Example: " + COMMAND_WORD + " i/Red Apple q/5 e/2021-12-25";
 
+    private static final String MESSAGE_QUANTITY_ZERO = "Cannot decrement by a quantity of zero.";
     private static final String MESSAGE_INGREDIENT_NOT_FOUND = "Sorry. No matching ingredients found!";
-    private static final String MESSAGE_QUANTITY_NEGATIVE = "Sorry, you currently only have %1$s of this ingredient.\n"
+    private static final String MESSAGE_QUANTITY_TOO_MUCH = "Sorry, you currently only have %1$s of this ingredient.\n"
             + "You cannot decrease it by %2$s.\n" + "\n%3$s";
     private static final String MESSAGE_INGREDIENT_DECREMENTED = "I've decremented this ingredient by %1$s:\n"
             + "\n%2$s";
@@ -52,8 +53,12 @@ public class DecrementCommand extends Command {
         try {
             ingredientStorage.remove(quantity);
         } catch (IllegalValueException e) {
-            return String.format(MESSAGE_QUANTITY_NEGATIVE, ingredientStorage.getQuantity(), quantity,
-                    ingredientStorage);
+            if (quantity == 0) {
+                return MESSAGE_QUANTITY_ZERO;
+            } else {
+                return String.format(MESSAGE_QUANTITY_TOO_MUCH, ingredientStorage.getQuantity(), quantity,
+                        ingredientStorage);
+            }
         }
         return String.format(MESSAGE_INGREDIENT_DECREMENTED, quantity, ingredientStorage);
     }

--- a/src/main/java/expiryeliminator/commands/IncrementCommand.java
+++ b/src/main/java/expiryeliminator/commands/IncrementCommand.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import expiryeliminator.data.IngredientRepository;
 import expiryeliminator.data.IngredientStorage;
 import expiryeliminator.data.RecipeList;
+import expiryeliminator.data.exception.IllegalValueException;
 import expiryeliminator.data.exception.NotFoundException;
 
 /**
@@ -18,6 +19,7 @@ public class IncrementCommand extends Command {
                     + "Parameters: i/INGREDIENT q/QUANTITY e/EXPIRY_DATE\n"
                     + "Example: " + COMMAND_WORD + " i/Red Apple q/3 e/2021-12-25";
 
+    private static final String MESSAGE_QUANTITY_ZERO = "Cannot increment by a quantity of zero.";
     private static final String MESSAGE_INGREDIENT_NOT_FOUND = "Sorry. No matching ingredients found!";
     private static final String MESSAGE_INGREDIENT_INCREMENTED = "I've incremented this ingredient by %1$s:\n"
             + "\n%2$s";
@@ -51,7 +53,11 @@ public class IncrementCommand extends Command {
         } catch (NotFoundException e) {
             return MESSAGE_INGREDIENT_NOT_FOUND;
         }
-        ingredientStorage.add(quantity, expiryDate);
+        try {
+            ingredientStorage.add(quantity, expiryDate);
+        } catch (IllegalValueException e) {
+            return MESSAGE_QUANTITY_ZERO;
+        }
         return String.format(MESSAGE_INGREDIENT_INCREMENTED, quantity, ingredientStorage);
     }
 }

--- a/src/main/java/expiryeliminator/commands/UpdateRecipeCommand.java
+++ b/src/main/java/expiryeliminator/commands/UpdateRecipeCommand.java
@@ -77,7 +77,7 @@ public class UpdateRecipeCommand extends Command {
                     return String.format(RECIPE_UPDATE_FAIL, name) + "\n\n" + MESSAGE_ILLEGAL_VALUE_ERROR;
                 } catch (NotFoundException e) {
                     try {
-                        recipe.add(ingredientName, quantity, ingredients);
+                        recipe.addIngredient(ingredientName, quantity, ingredients);
                     } catch (DuplicateDataException | IllegalValueException ex) {
                         return String.format(RECIPE_UPDATE_FAIL, name);
                     }

--- a/src/main/java/expiryeliminator/data/Ingredient.java
+++ b/src/main/java/expiryeliminator/data/Ingredient.java
@@ -52,6 +52,7 @@ public class Ingredient {
      * @param unit The unit for the ingredient.
      */
     void setUnit(String unit) {
+        assert unit == null || !unit.isBlank();
         this.unit = unit;
     }
 

--- a/src/main/java/expiryeliminator/data/IngredientRepository.java
+++ b/src/main/java/expiryeliminator/data/IngredientRepository.java
@@ -83,19 +83,6 @@ public class IngredientRepository {
     }
 
     /**
-     * Removes a batch of ingredients based on the given expiry date.
-     *
-     * @param ingredientName Name of ingredient.
-     * @param expiryDate Expiry date of batch of ingredients to be removed.
-     * @throws NotFoundException If ingredient does not exist in the repository.
-     * @throws IllegalValueException If the ingredient does not have any batch with the given expiry date.
-     */
-    public void remove(String ingredientName, LocalDate expiryDate) throws NotFoundException, IllegalValueException {
-        final IngredientStorage ingredientStorage = find(ingredientName);
-        ingredientStorage.remove(expiryDate);
-    }
-
-    /**
      * Removes ingredient from the ingredient repository.
      *
      * @param ingredientName Name of ingredient to be removed.

--- a/src/main/java/expiryeliminator/data/IngredientRepository.java
+++ b/src/main/java/expiryeliminator/data/IngredientRepository.java
@@ -57,9 +57,10 @@ public class IngredientRepository {
      * @param expiryDate Expiry date of ingredient.
      * @return Ingredient storage object corresponding to the added ingredient.
      * @throws DuplicateDataException If ingredient already exists in the repository.
+     * @throws IllegalValueException If quantity to be added is less than or equal to 0.
      */
     public IngredientStorage add(String ingredientName, String unit, int quantity, LocalDate expiryDate)
-            throws DuplicateDataException {
+            throws DuplicateDataException, IllegalValueException {
         assert ingredientName != null : "Ingredient name cannot be null";
         assert expiryDate != null : "Expiry date cannot be null";
         checkDuplicateIngredient(ingredientName);
@@ -163,7 +164,12 @@ public class IngredientRepository {
 
             for (LocalDate expiryDate : ingredientStorage.getIngredientBatches().keySet()) {
                 if (expiryDate.isAfter(currentDate) && expiryDate.isBefore(currentDatePlusAWeek)) {
-                    expiredIngredientStorage.add(ingredientStorage.getIngredientBatches().get(expiryDate), expiryDate);
+                    try {
+                        expiredIngredientStorage.add(ingredientStorage.getIngredientBatches().get(expiryDate),
+                                expiryDate);
+                    } catch (IllegalValueException e) {
+                        assert false : "Quantity added to ingredient storage should have been greater than zero.";
+                    }
                     hasExpiringIngredients = true;
                 }
             }
@@ -193,7 +199,12 @@ public class IngredientRepository {
 
             for (LocalDate expiryDate : ingredientStorage.getIngredientBatches().keySet()) {
                 if (expiryDate.isBefore(currentDate)) {
-                    expiredIngredientStorage.add(ingredientStorage.getIngredientBatches().get(expiryDate), expiryDate);
+                    try {
+                        expiredIngredientStorage.add(ingredientStorage.getIngredientBatches().get(expiryDate),
+                                expiryDate);
+                    } catch (IllegalValueException e) {
+                        assert false : "Quantity added to ingredient storage should have been greater than zero.";
+                    }
                     hasExpiredIngredients = true;
                 }
             }

--- a/src/main/java/expiryeliminator/data/IngredientStorage.java
+++ b/src/main/java/expiryeliminator/data/IngredientStorage.java
@@ -80,17 +80,6 @@ public class IngredientStorage {
     }
 
     /**
-     * Updates the quantity of a batch of ingredients based on the given expiry date.
-     *
-     * @param quantity New quantity.
-     * @param expiryDate Expiry date of batch of ingredients to update.
-     */
-    public void update(int quantity, LocalDate expiryDate) {
-        assert expiryDate != null : "Expiry date cannot be null";
-        ingredientBatches.put(expiryDate, quantity);
-    }
-
-    /**
      * Removes a quantity of ingredients from the storage.
      * Removes from the earliest batch of expiry date first.
      *

--- a/src/main/java/expiryeliminator/data/IngredientStorage.java
+++ b/src/main/java/expiryeliminator/data/IngredientStorage.java
@@ -84,11 +84,15 @@ public class IngredientStorage {
      * Removes from the earliest batch of expiry date first.
      *
      * @param quantity Quantity to be removed.
-     * @throws IllegalValueException If quantity to be removed exceeds the current available quantity.
+     * @throws IllegalValueException If quantity to be removed exceeds the current available quantity or if
+     *         quantity to be removed is less than or equal to 0.
      */
     public void remove(int quantity) throws IllegalValueException {
         if (this.quantity < quantity) {
-            throw new IllegalValueException();
+            throw new IllegalValueException("Quantity to be removed exceeds current available quantity");
+        }
+        if (quantity <= 0) {
+            throw new IllegalValueException("Quantity to be removed is less than or equal to 0");
         }
 
         int toRemove = quantity;

--- a/src/main/java/expiryeliminator/data/IngredientStorage.java
+++ b/src/main/java/expiryeliminator/data/IngredientStorage.java
@@ -68,8 +68,12 @@ public class IngredientStorage {
      *
      * @param quantity Quantity of batch of ingredients to be added.
      * @param expiryDate Expiry date of batch of ingredients to be added.
+     * @throws IllegalValueException If quantity to be added is less than or equal to 0.
      */
-    public void add(int quantity, LocalDate expiryDate) {
+    public void add(int quantity, LocalDate expiryDate) throws IllegalValueException {
+        if (quantity <= 0) {
+            throw new IllegalValueException();
+        }
         assert expiryDate != null : "Expiry date cannot be null";
         if (ingredientBatches.containsKey(expiryDate)) {
             ingredientBatches.replace(expiryDate, ingredientBatches.get(expiryDate) + quantity);

--- a/src/main/java/expiryeliminator/data/IngredientStorage.java
+++ b/src/main/java/expiryeliminator/data/IngredientStorage.java
@@ -113,7 +113,7 @@ public class IngredientStorage {
      * @param expiryDate Expiry date of batch of ingredients to be removed.
      */
     public void remove(LocalDate expiryDate) {
-        //assert expiryDate != null : "Expiry date cannot be null";
+        assert expiryDate != null : "Expiry date cannot be null";
         final Integer quantity = ingredientBatches.remove(expiryDate);
         this.quantity -= quantity;
     }

--- a/src/main/java/expiryeliminator/data/Recipe.java
+++ b/src/main/java/expiryeliminator/data/Recipe.java
@@ -50,16 +50,17 @@ public class Recipe {
     }
 
     //@@author vincentlauhl
+
     /**
      * Adds an ingredient and its associated quantity to the recipe.
      *
-     * @param ingredientName       Name of ingredient to be added.
-     * @param quantity             Quantity of ingredient to be added.
+     * @param ingredientName Name of ingredient to be added.
+     * @param quantity Quantity of ingredient to be added.
      * @param ingredientRepository Ingredient repository.
      * @throws DuplicateDataException If ingredient already exists in the recipe.
-     * @throws IllegalValueException  If quantity is less than or equal to 0.
+     * @throws IllegalValueException If quantity is less than or equal to 0.
      */
-    public String add(String ingredientName, int quantity, IngredientRepository ingredientRepository)
+    public String addIngredient(String ingredientName, int quantity, IngredientRepository ingredientRepository)
             throws DuplicateDataException, IllegalValueException {
         String ingredientNameIfNotInList = "";
         final IngredientStorage ingredientStorage = ingredientRepository.findWithNullReturn(ingredientName);
@@ -101,7 +102,7 @@ public class Recipe {
      * Updates the quantity of ingredients in a recipe.
      *
      * @param ingredientName Name of ingredient to be added.
-     * @param quantity       quantity of ingredient to be updated to.
+     * @param quantity quantity of ingredient to be updated to.
      */
     public void update(String ingredientName, int quantity) throws NotFoundException, IllegalValueException {
         if (!contains(ingredientName)) {

--- a/src/main/java/expiryeliminator/data/exception/DuplicateDataException.java
+++ b/src/main/java/expiryeliminator/data/exception/DuplicateDataException.java
@@ -9,5 +9,20 @@ package expiryeliminator.data.exception;
  * Signals an error caused by duplicate data where there should be none.
  */
 public class DuplicateDataException extends Exception {
+    /**
+     * Initialises exception without any error message.
+     */
+    public DuplicateDataException() {
+        super();
+    }
+
+    /**
+     * Initialises exception and stores error message.
+     *
+     * @param message Error message.
+     */
+    public DuplicateDataException(String message) {
+        super(message);
+    }
 }
 //@@author

--- a/src/main/java/expiryeliminator/data/exception/IllegalValueException.java
+++ b/src/main/java/expiryeliminator/data/exception/IllegalValueException.java
@@ -9,5 +9,20 @@ package expiryeliminator.data.exception;
  * Signals that some given data does not fulfill some constraints.
  */
 public class IllegalValueException extends Exception {
+    /**
+     * Initialises exception without any error message.
+     */
+    public IllegalValueException() {
+        super();
+    }
+
+    /**
+     * Initialises exception and stores error message.
+     *
+     * @param message Error message.
+     */
+    public IllegalValueException(String message) {
+        super(message);
+    }
 }
 //@@author

--- a/src/main/java/expiryeliminator/parser/ArgsParser.java
+++ b/src/main/java/expiryeliminator/parser/ArgsParser.java
@@ -27,7 +27,7 @@ class ArgsParser {
      * Used for separation of each prefix and argument.
      * E.g. this matches "/a aaaaa aaaa"
      */
-    private static final Pattern ARGS_FORMAT = Pattern.compile("\\w+/([^/\\s]+( +|$))+");
+    private static final Pattern ARGS_FORMAT = Pattern.compile("\\w+/([^/\\s]*( +|$))+");
 
     private final ArrayList<Prefix> prefixList;
 
@@ -68,10 +68,18 @@ class ArgsParser {
 
     private void findAndPopulateArgs(Matcher matcher) throws InvalidPrefixException {
         while (matcher.find()) {
-            final String match = matcher.group();
+            final String match = matcher.group().trim();
             final String[] prefixAndArg = match.split("/");
             final String prefix = prefixAndArg[0];
-            final String arg = prefixAndArg[1].trim();
+            String arg = null;
+            if (prefixAndArg.length == 2) {
+                arg = prefixAndArg[1];
+                // Throw error if first character is a space as that is not allowed.
+                if (Character.isSpaceChar(arg.charAt(0))) {
+                    throw new InvalidPrefixException(prefix);
+                }
+                arg = arg.trim();
+            }
             try {
                 prefixesToArgs.get(prefix).add(arg);
             } catch (NullPointerException error) {

--- a/src/main/java/expiryeliminator/parser/Parser.java
+++ b/src/main/java/expiryeliminator/parser/Parser.java
@@ -58,7 +58,8 @@ public class Parser {
     private static final SingleArgPrefix PREFIX_INGREDIENT = new SingleArgPrefix("i");
     private static final SingleArgPrefix PREFIX_QUANTITY = new SingleArgPrefix("q");
     private static final SingleArgPrefix PREFIX_EXPIRY = new SingleArgPrefix("e");
-    private static final OptionalArgPrefix PREFIX_OPTIONAL_UNIT = new OptionalArgPrefix("u");
+    private static final SingleArgPrefix PREFIX_UNIT = new SingleArgPrefix("u");
+    private static final OptionalArgPrefix PREFIX_OPTIONAL_UNIT = new OptionalArgPrefix(PREFIX_UNIT);
     private static final MultipleArgPrefix PREFIX_MULTIPLE_INGREDIENT = new MultipleArgPrefix(PREFIX_INGREDIENT);
     private static final MultipleArgPrefix PREFIX_MULTIPLE_QUANTITY = new MultipleArgPrefix(PREFIX_QUANTITY);
     private static final MultipleArgPrefix PREFIX_MULTIPLE_RECIPE = new MultipleArgPrefix(PREFIX_RECIPE);
@@ -80,7 +81,7 @@ public class Parser {
         if (!matcher.matches()) {
             return new IncorrectCommand(MESSAGE_UNRECOGNISED_COMMAND);
         }
-        final String command = matcher.group("command");
+        final String command = matcher.group("command").trim();
         String args = matcher.group("args");
 
         try {
@@ -190,6 +191,7 @@ public class Parser {
     }
 
     //@@author vincentlauhl
+
     /**
      * Creates a AddRecipeCommand from the inputs.
      *
@@ -287,6 +289,7 @@ public class Parser {
     }
 
     //@@author vincentlauhl
+
     /**
      * Creates a CookedRecipeCommand from the inputs.
      *
@@ -351,7 +354,7 @@ public class Parser {
      * @return a DeleteRecipeCommand with the recipe name if successful and an IncorrectCommand if not.
      */
     private static Command prepareUpdateUnits(String args) throws InvalidArgFormatException {
-        final ArgsParser argsParser = new ArgsParser(PREFIX_INGREDIENT, PREFIX_OPTIONAL_UNIT);
+        final ArgsParser argsParser = new ArgsParser(PREFIX_INGREDIENT, PREFIX_UNIT);
 
         try {
             argsParser.parse(args);
@@ -361,7 +364,7 @@ public class Parser {
         }
 
 
-        final String unitString = new UnitParser().parse(argsParser.getSingleArg(PREFIX_OPTIONAL_UNIT));
+        final String unitString = new UnitParser().parse(argsParser.getSingleArg(PREFIX_UNIT));
         final String ingredient = new IngredientParser().parse(argsParser.getSingleArg(PREFIX_INGREDIENT));
 
         return new UpdateUnitsCommand(ingredient, unitString);

--- a/src/main/java/expiryeliminator/parser/argparser/IngredientParser.java
+++ b/src/main/java/expiryeliminator/parser/argparser/IngredientParser.java
@@ -7,6 +7,7 @@ import expiryeliminator.parser.exception.InvalidArgFormatException;
  * Parses ingredient name.
  */
 public class IngredientParser extends MultipleArgParser<String> {
+    public static final String MESSAGE_BLANK_INGREDIENT = "Ingredient name cannot be blank";
     private static final String MESSAGE_INVALID_INGREDIENT = "Ingredient name must only consist of letters, "
             + "not numbers or other special digits.";
 
@@ -19,7 +20,7 @@ public class IngredientParser extends MultipleArgParser<String> {
      */
     @Override
     public String parse(String ingredientString) throws InvalidArgFormatException {
-        checkArgNotBlank(ingredientString, "Ingredient name cannot be blank.");
+        checkArgNotBlank(ingredientString, MESSAGE_BLANK_INGREDIENT);
         if (!Utils.isAlphabetic(ingredientString)) {
             throw new InvalidArgFormatException(MESSAGE_INVALID_INGREDIENT);
         }

--- a/src/main/java/expiryeliminator/parser/argparser/QuantityParser.java
+++ b/src/main/java/expiryeliminator/parser/argparser/QuantityParser.java
@@ -6,6 +6,7 @@ import expiryeliminator.parser.exception.InvalidArgFormatException;
  * Parses quantity.
  */
 public class QuantityParser extends MultipleArgParser<Integer> {
+    public static final String MESSAGE_BLANK_QUANTITY = "Quantity cannot be blank";
     private static final String MESSAGE_INVALID_NUMBER = "Quantity must be a valid number.";
     private static final String MESSAGE_NEGATIVE_NUMBER = "Quantity cannot be a negative number.";
 
@@ -18,7 +19,7 @@ public class QuantityParser extends MultipleArgParser<Integer> {
      */
     @Override
     public Integer parse(String quantityString) throws InvalidArgFormatException {
-        checkArgNotBlank(quantityString, "Quantity cannot be blank.");
+        checkArgNotBlank(quantityString, MESSAGE_BLANK_QUANTITY);
         try {
             final int quantity = Integer.parseInt(quantityString);
             if (quantity < 0) {

--- a/src/main/java/expiryeliminator/parser/argparser/RecipeParser.java
+++ b/src/main/java/expiryeliminator/parser/argparser/RecipeParser.java
@@ -7,6 +7,7 @@ import expiryeliminator.parser.exception.InvalidArgFormatException;
  * Parses recipe name.
  */
 public class RecipeParser extends MultipleArgParser<String> {
+    public static final String MESSAGE_BLANK_RECIPE = "Recipe name cannot be blank";
     private static final String MESSAGE_INVALID_RECIPE = "Recipe name must only consist of letters, "
             + "not numbers or other special digits.";
 
@@ -18,7 +19,7 @@ public class RecipeParser extends MultipleArgParser<String> {
      * @throws InvalidArgFormatException If the string is blank.
      */
     public String parse(String recipeString) throws InvalidArgFormatException {
-        checkArgNotBlank(recipeString, "Recipe name cannot be blank.");
+        checkArgNotBlank(recipeString, MESSAGE_BLANK_RECIPE);
         if (!Utils.isAlphabetic(recipeString)) {
             throw new InvalidArgFormatException(MESSAGE_INVALID_RECIPE);
         }

--- a/src/main/java/expiryeliminator/parser/prefix/OptionalArgPrefix.java
+++ b/src/main/java/expiryeliminator/parser/prefix/OptionalArgPrefix.java
@@ -5,11 +5,11 @@ package expiryeliminator.parser.prefix;
  */
 public class OptionalArgPrefix extends SingleArgPrefix {
     /**
-     * Initialises optional arg prefix with a prefix string.
+     * Initialises optional arg prefix.
      *
-     * @param prefix Prefix.
+     * @param singleArgPrefix Prefix that should be allowed to be optional.
      */
-    public OptionalArgPrefix(String prefix) {
-        super(prefix);
+    public OptionalArgPrefix(SingleArgPrefix singleArgPrefix) {
+        super(singleArgPrefix.getPrefix());
     }
 }

--- a/src/main/java/expiryeliminator/storage/LoadData.java
+++ b/src/main/java/expiryeliminator/storage/LoadData.java
@@ -1,5 +1,10 @@
 package expiryeliminator.storage;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.time.LocalDate;
+import java.util.Scanner;
+
 import expiryeliminator.data.Ingredient;
 import expiryeliminator.data.IngredientQuantity;
 import expiryeliminator.data.IngredientRepository;
@@ -8,11 +13,6 @@ import expiryeliminator.data.Recipe;
 import expiryeliminator.data.RecipeList;
 import expiryeliminator.data.exception.DuplicateDataException;
 import expiryeliminator.data.exception.IllegalValueException;
-
-import java.time.LocalDate;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.util.Scanner;
 
 public class LoadData {
 
@@ -39,8 +39,8 @@ public class LoadData {
     /**
      * Store the current recipe from the txt file to the recipe list.
      *
-     * @param recipes       The whole recipe list.
-     * @param sc            The scanner.
+     * @param recipes The whole recipe list.
+     * @param sc The scanner.
      * @param currentRecipe The current recipe that is going to be stored.
      */
     private static void storeCurrentRecipeFromList(RecipeList recipes, Scanner sc, Recipe currentRecipe)
@@ -69,7 +69,7 @@ public class LoadData {
      * Stores the current ingredient of a recipe from the txt file.
      *
      * @param currentRecipe The current recipe that is stored.
-     * @param line          The current line of the txt file.
+     * @param line The current line of the txt file.
      */
     private static void storeCurrentIngredientOfRecipe(Recipe currentRecipe, String line)
             throws IllegalValueException {
@@ -90,9 +90,9 @@ public class LoadData {
     /**
      * Gets the current unit of an ingredient from the txt file.
      *
-     * @param line           The current line of a txt file.
+     * @param line The current line of a txt file.
      * @param unitStartIndex The starting index of the unit substring.
-     * @param unitEndIndex   The ending index of the unit substring.
+     * @param unitEndIndex The ending index of the unit substring.
      */
     private static String getUnitForIngredientRepo(String line, int unitStartIndex, int unitEndIndex) {
         String unit = line.substring(unitStartIndex, unitEndIndex);
@@ -118,7 +118,7 @@ public class LoadData {
             loadCurrentIngredientFromRepo(ingredients, sc);
         } catch (FileNotFoundException e) {
             SaveData.createFileOrFolder(pathName, fileName);
-        } catch (DuplicateDataException e) {
+        } catch (DuplicateDataException | IllegalValueException e) {
             e.printStackTrace();
         }
     }
@@ -126,7 +126,7 @@ public class LoadData {
     /**
      * Gets the current quantity of the ingredient with batch number from the txt file.
      *
-     * @param line            The current line of a txt file.
+     * @param line The current line of a txt file.
      * @param expiryDateStart The start index of the expiry date substring.
      */
     private static int getQuantityWithBatch(String line, int expiryDateStart) {
@@ -162,10 +162,10 @@ public class LoadData {
      * Loads the current ingredient from the txt file.
      *
      * @param ingredients The whole ingredient repository.
-     * @param sc          The scanner.
+     * @param sc The scanner.
      */
     private static void loadCurrentIngredientFromRepo(IngredientRepository ingredients, Scanner sc)
-            throws DuplicateDataException {
+            throws DuplicateDataException, IllegalValueException {
         LocalDate expiryDate = null;
         String unit = null;
         String ingredientName = null;

--- a/src/test/java/expiryeliminator/parser/ParserTest.java
+++ b/src/test/java/expiryeliminator/parser/ParserTest.java
@@ -10,14 +10,15 @@ import expiryeliminator.commands.AddRecipeCommand;
 import expiryeliminator.commands.DeleteRecipeCommand;
 import expiryeliminator.data.IngredientRepository;
 import expiryeliminator.data.RecipeList;
+import expiryeliminator.parser.argparser.IngredientParser;
+import expiryeliminator.parser.argparser.QuantityParser;
+import expiryeliminator.parser.argparser.RecipeParser;
 import expiryeliminator.util.TestUtil;
 
 class ParserTest {
     @Test
     public void prepareAddRecipe_incorrectFormats_ErrorMessage() {
-        String[] tests = {"add recipe r/chicken soup i/chicken q/",
-                          "add recipe r/chicken soup i/ q/1",
-                          "add recipe r/chicken soup",
+        String[] tests = {"add recipe r/chicken soup",
                           "add recipe r/Apple Pie",
                           "add recipe i/Red Apple q/4 i/Green Apple q/4"};
 
@@ -25,6 +26,20 @@ class ParserTest {
             assertEquals(parseCommand(test).execute(null, null),
                     String.format(Parser.MESSAGE_INVALID_COMMAND_FORMAT, AddRecipeCommand.MESSAGE_USAGE));
         }
+    }
+
+    @Test
+    public void prepareAddRecipe_quantityBlank_ErrorMessage() {
+        String test = "add recipe r/chicken soup i/chicken q/";
+        assertEquals(String.format(Parser.MESSAGE_INVALID_ARGUMENT_FORMAT, QuantityParser.MESSAGE_BLANK_QUANTITY),
+                parseCommand(test).execute(null, null));
+    }
+
+    @Test
+    public void prepareAddRecipe_ingredientBlank_ErrorMessage() {
+        String test = "add recipe r/chicken soup i/ q/1";
+        assertEquals(String.format(Parser.MESSAGE_INVALID_ARGUMENT_FORMAT, IngredientParser.MESSAGE_BLANK_INGREDIENT),
+                parseCommand(test).execute(null, null));
     }
 
     @Test
@@ -72,6 +87,6 @@ class ParserTest {
     public void prepareDeleteRecipe_incorrectFormat_ErrorMessage() {
         String test = "delete recipe r/";
         assertEquals(parseCommand(test).execute(null, null),
-                String.format(Parser.MESSAGE_INVALID_COMMAND_FORMAT, DeleteRecipeCommand.MESSAGE_USAGE));
+                String.format(Parser.MESSAGE_INVALID_ARGUMENT_FORMAT, RecipeParser.MESSAGE_BLANK_RECIPE));
     }
 }

--- a/src/test/java/expiryeliminator/util/TestUtil.java
+++ b/src/test/java/expiryeliminator/util/TestUtil.java
@@ -6,11 +6,11 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 
+import expiryeliminator.data.IngredientQuantity;
 import expiryeliminator.data.IngredientRepository;
 import expiryeliminator.data.IngredientStorage;
 import expiryeliminator.data.Recipe;
 import expiryeliminator.data.RecipeList;
-import expiryeliminator.data.IngredientQuantity;
 import expiryeliminator.data.exception.DuplicateDataException;
 import expiryeliminator.data.exception.IllegalValueException;
 import expiryeliminator.data.exception.NotFoundException;
@@ -48,7 +48,7 @@ public class TestUtil {
     }
 
     public static void addIngredientsWithoutUnitsToRecipe(Recipe recipe) {
-        final IngredientRepository ingredientRepository = generateIngredientRepositoryForExampleRecipe(1,20);
+        final IngredientRepository ingredientRepository = generateIngredientRepositoryForExampleRecipe(1, 20);
         assert ingredientRepository != null;
         try {
             recipe.add("Chicken", 1, ingredientRepository);
@@ -177,11 +177,19 @@ public class TestUtil {
 
         try {
             //expiring
-            ingredientRepository.add("Chicken", null, quantity1, currentDatePlusThreeDays);
+            if (quantity1 <= 0) {
+                ingredientRepository.add("Chicken");
+            } else {
+                ingredientRepository.add("Chicken", null, quantity1, currentDatePlusThreeDays);
+            }
             //fresh
-            ingredientRepository.add("Salt", null, quantity2, currentDatePlusThreeWeeks);
+            if (quantity2 <= 0) {
+                ingredientRepository.add("Salt");
+            } else {
+                ingredientRepository.add("Salt", null, quantity2, currentDatePlusThreeWeeks);
+            }
             return ingredientRepository;
-        } catch (DuplicateDataException e) {
+        } catch (DuplicateDataException | IllegalValueException e) {
             fail("Ingredient repository should be valid by definition");
             return null;
         }
@@ -205,7 +213,7 @@ public class TestUtil {
             ingredientRepository.add("Chicken", null, quantity1, currentDateMinusThreeDays);
             ingredientRepository.add("Salt", null, quantity2, currentDateMinusThreeWeeks);
             return ingredientRepository;
-        } catch (DuplicateDataException e) {
+        } catch (DuplicateDataException | IllegalValueException e) {
             fail("Ingredient repository should be valid by definition");
             return null;
         }
@@ -222,9 +230,9 @@ public class TestUtil {
 
         try {
             final IngredientRepository ingredients = new IngredientRepository();
-            ingredients.add("Chicken",null, 1, currentDatePlusThreeDays);
+            ingredients.add("Chicken", null, 1, currentDatePlusThreeDays);
             return ingredients.find("Chicken");
-        } catch (DuplicateDataException e) {
+        } catch (DuplicateDataException | IllegalValueException e) {
             fail("Ingredient repository should be valid by definition");
             return null;
         } catch (NotFoundException e) {
@@ -244,9 +252,9 @@ public class TestUtil {
 
         try {
             final IngredientRepository ingredients = new IngredientRepository();
-            ingredients.add("Salt",null, 20, currentDatePlusThreeWeeks);
+            ingredients.add("Salt", null, 20, currentDatePlusThreeWeeks);
             return ingredients.find("Salt");
-        } catch (DuplicateDataException e) {
+        } catch (DuplicateDataException | IllegalValueException e) {
             fail("Ingredient repository should be valid by definition");
             return null;
         } catch (NotFoundException e) {
@@ -284,7 +292,7 @@ public class TestUtil {
             //fresh
             ingredientRepository.add("Green Apple", null, 3, currentDatePlusThreeWeeks);
             return ingredientRepository;
-        } catch (DuplicateDataException e) {
+        } catch (DuplicateDataException | IllegalValueException e) {
             fail("Ingredient repository should be valid by definition");
             return null;
         }
@@ -308,7 +316,7 @@ public class TestUtil {
             //fresh
             ingredientRepository.add("Green Apple", null, 3, currentDatePlusThreeWeeks);
             return ingredientRepository;
-        } catch (DuplicateDataException e) {
+        } catch (DuplicateDataException | IllegalValueException e) {
             fail("Ingredient repository should be valid by definition");
             return null;
         }

--- a/src/test/java/expiryeliminator/util/TestUtil.java
+++ b/src/test/java/expiryeliminator/util/TestUtil.java
@@ -29,8 +29,8 @@ public class TestUtil {
         final IngredientRepository ingredientRepository = generateIngredientRepositoryForRecipe();
         assert ingredientRepository != null;
         try {
-            recipe.add("Chicken", 1, ingredientRepository);
-            recipe.add("Salt", 20, ingredientRepository);
+            recipe.addIngredient("Chicken", 1, ingredientRepository);
+            recipe.addIngredient("Salt", 20, ingredientRepository);
         } catch (DuplicateDataException | IllegalValueException e) {
             fail("Recipe should be valid by definition");
         }
@@ -40,8 +40,8 @@ public class TestUtil {
         final IngredientRepository ingredientRepository = generateIngredientRepositoryForRecipe();
         assert ingredientRepository != null;
         try {
-            recipe.add("Pork", 1, ingredientRepository);
-            recipe.add("Salt", 20, ingredientRepository);
+            recipe.addIngredient("Pork", 1, ingredientRepository);
+            recipe.addIngredient("Salt", 20, ingredientRepository);
         } catch (DuplicateDataException | IllegalValueException e) {
             fail("Recipe should be valid by definition");
         }
@@ -51,8 +51,8 @@ public class TestUtil {
         final IngredientRepository ingredientRepository = generateIngredientRepositoryForExampleRecipe(1, 20);
         assert ingredientRepository != null;
         try {
-            recipe.add("Chicken", 1, ingredientRepository);
-            recipe.add("Salt", 20, ingredientRepository);
+            recipe.addIngredient("Chicken", 1, ingredientRepository);
+            recipe.addIngredient("Salt", 20, ingredientRepository);
         } catch (DuplicateDataException | IllegalValueException e) {
             fail("Recipe should be valid by definition");
         }


### PR DESCRIPTION
Fixes the bug whereby `increment i/INGREDIENT q/0 e/EXPIRY` and `decrement i/INGREDIENT q/0 e/EXPIRY` is allowed.
Also fixes the bug whereby `add i/INGREDIENT u/ UNIT` and `add update i/INGREDIENT u/ UNIT` (notice the space between `u/` and `UNIT`) causes the unit to be shown as blank.

Fixes #121, fixes #123